### PR TITLE
Prevent nested anchors in header logo

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -53,7 +53,7 @@ export function Header() {
     >
       <Container className="flex h-16 items-center justify-between gap-4 md:h-20">
         <Link href="/" className="flex items-center gap-3 text-white" aria-label="Arctura Analytics home">
-          <Logo usePng size={28} />
+          <Logo usePng size={28} withLink={false} showText={false} />
           <div className="flex flex-col leading-tight">
             <span className="font-heading text-xs uppercase tracking-[0.6em]">Arctura</span>
             <span className="text-[0.65rem] uppercase tracking-[0.38em] text-white/60">Analytics</span>

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,24 +1,56 @@
 import Image from 'next/image'
 import Link from 'next/link'
 
+type LogoVariant = 'dark' | 'light'
+
 type Props = {
   size?: number
   priority?: boolean
-  variant?: 'dark' | 'light'
+  variant?: LogoVariant
   usePng?: boolean
   showText?: boolean
   textClassName?: string
+  className?: string
+  withLink?: boolean
+  href?: string
+  ariaLabel?: string
 }
 
-export function Logo({ size = 32, priority = true, variant = 'dark', usePng = false, showText = true, textClassName }: Props) {
+export function Logo({
+  size = 32,
+  priority = true,
+  variant = 'dark',
+  usePng = false,
+  showText = true,
+  textClassName,
+  className,
+  withLink = true,
+  href = '/',
+  ariaLabel = 'Arctura Analytics home',
+}: Props) {
   const svgSrc = variant === 'light' ? '/brand/logo-light.svg' : '/brand/logo-dark.svg'
   const src = usePng ? '/brand/Arctura_Logo.png' : svgSrc
-  return (
-    <Link href="/" className="flex items-center gap-2" aria-label="Arctura Analytics home">
+  const containerClass = ['flex items-center gap-2', className].filter(Boolean).join(' ')
+  const content = (
+    <>
       <Image src={src} alt="Arctura Analytics" width={size} height={size} priority={priority} />
       {showText ? (
         <span className={textClassName ?? 'text-base font-semibold tracking-wide'}>Arctura Analytics</span>
       ) : null}
-    </Link>
+    </>
+  )
+
+  if (withLink) {
+    return (
+      <Link href={href} className={containerClass} aria-label={ariaLabel}>
+        {content}
+      </Link>
+    )
+  }
+
+  return (
+    <span className={containerClass}>
+      {content}
+    </span>
   )
 }


### PR DESCRIPTION
## Summary
- extend the Logo component so it can render with or without an anchor wrapper and accept extra configuration
- update the header logo usage to disable the internal link and text, preventing nested anchor tags during hydration

## Testing
- npm run lint *(fails: existing parsing error in src/app/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ecaeccec832fb38e4c486b862eb9