### PR TITLE
Refine dark volcanic theme across site

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -149,7 +149,7 @@ export default function AboutPage() {
   const reduceMotion = useReducedMotion()
 
   return (
-    <main id="content" className="bg-black text-white">
+    <main id="content" className="bg-[color:var(--bg)] text-[color:var(--fg)]">
       <section className="relative isolate overflow-hidden">
         <Image
           src="/brand/georgie-cobbs-muOHbrFGEQY-unsplash.jpg"
@@ -159,11 +159,11 @@ export default function AboutPage() {
           className="object-cover"
         />
         <div
-          className="absolute inset-0 bg-gradient-to-b from-black via-black/80 to-[#080509]"
+          className="absolute inset-0 bg-[radial-gradient(110%_160%_at_50%_-20%,rgba(255,104,64,0.28),transparent_55%),linear-gradient(to_bottom,#050203,rgba(6,3,4,0.92),#050203)]"
           aria-hidden
         />
         <div
-          className="absolute inset-0 bg-gradient-to-r from-black/20 via-[#1f0d0b]/60 to-black/50"
+          className="absolute inset-0 bg-gradient-to-r from-[rgba(20,6,8,0.55)] via-[rgba(10,4,6,0.8)] to-[rgba(6,2,4,0.65)]"
           aria-hidden
         />
         <Container className="relative z-[1] space-y-12 py-28 sm:py-32">
@@ -173,14 +173,14 @@ export default function AboutPage() {
             transition={{ duration: 0.6, ease: 'easeOut' }}
             className="max-w-3xl space-y-6"
           >
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-white/70">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
               About Arctura
             </span>
             <h1 className="text-balance text-4xl font-black leading-tight sm:text-5xl lg:text-6xl">
               We choreograph national registries and digital platforms so the public experiences
               confident, human government.
             </h1>
-            <p className="max-w-2xl text-balance text-base text-white/75 sm:text-lg">
+            <p className="max-w-2xl text-balance text-base text-muted sm:text-lg">
               From the eGovRegistry backbone in Nigeria to modular civic platforms across emerging
               cities, Arctura blends policy, engineering, and service design into one disciplined
               squad. We help ministries deliver certainty to citizens, businesses, and partners at
@@ -194,13 +194,13 @@ export default function AboutPage() {
                 initial={reduceMotion ? undefined : { opacity: 0, y: 24 }}
                 animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
                 transition={{ duration: 0.5, ease: 'easeOut', delay: index * 0.08 + 0.2 }}
-                className="rounded-3xl border border-white/15 bg-white/10 p-6 backdrop-blur"
+                className="surface-card rounded-3xl border border-[color:var(--border)] p-6"
               >
-                <div className="text-2xl font-semibold text-white sm:text-3xl">{metric.value}</div>
-                <div className="mt-2 text-xs uppercase tracking-[0.3em] text-white/60">
+                <div className="text-2xl font-semibold text-[color:var(--ink)] sm:text-3xl">{metric.value}</div>
+                <div className="mt-2 text-xs uppercase tracking-[0.3em] text-muted">
                   {metric.label}
                 </div>
-                <p className="mt-3 text-sm text-white/70">{metric.copy}</p>
+                <p className="mt-3 text-sm text-muted">{metric.copy}</p>
               </motion.article>
             ))}
           </div>
@@ -210,19 +210,19 @@ export default function AboutPage() {
       <Section className="relative overflow-hidden py-24">
         <div className="absolute inset-0 -z-10">
           <div
-            className="absolute inset-x-0 top-0 h-48 bg-[radial-gradient(75%_120%_at_50%_0%,rgba(255,111,60,0.18),transparent_70%)]"
+            className="absolute inset-x-0 top-0 h-48 bg-[radial-gradient(75%_120%_at_50%_0%,rgba(255,112,68,0.2),transparent_70%)]"
             aria-hidden
           />
         </div>
         <Container className="space-y-12">
-          <div className="max-w-3xl space-y-5 text-white">
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/12 bg-white/10 px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-white/70">
+          <div className="max-w-3xl space-y-5">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
               What we deliver
             </span>
             <h2 className="text-3xl font-black sm:text-4xl">
               Programmes that connect ministries, markets, and everyday people.
             </h2>
-            <p className="text-base text-white/75 sm:text-lg">
+            <p className="text-base text-muted sm:text-lg">
               Our cross-functional squads translate policy mandates into real products. Each track
               merges lessons from the digital platform and registry initiatives into one coherent
               journey.
@@ -236,18 +236,18 @@ export default function AboutPage() {
                 whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
                 transition={{ duration: 0.55, ease: 'easeOut', delay: index * 0.08 }}
-                className="flex h-full flex-col gap-4 rounded-[28px] border border-white/12 bg-[color:rgba(12,15,23,0.92)] p-8 shadow-[0_32px_120px_rgba(4,6,15,0.55)]"
+                className="surface-card flex h-full flex-col gap-4 rounded-[28px] border border-[color:var(--border)] p-8"
               >
-                <span className="inline-flex w-max items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[0.62rem] uppercase tracking-[0.32em] text-white/70">
+                <span className="inline-flex w-max items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-3 py-1 text-[0.62rem] uppercase tracking-[0.32em] text-muted">
                   {track.kicker}
                 </span>
-                <h3 className="text-xl font-semibold text-white">{track.title}</h3>
-                <p className="text-sm text-white/75">{track.description}</p>
-                <ul className="space-y-2 text-sm text-white/70">
+                <h3 className="text-xl font-semibold text-[color:var(--ink)]">{track.title}</h3>
+                <p className="text-sm text-muted">{track.description}</p>
+                <ul className="space-y-2 text-sm text-muted">
                   {track.highlights.map((highlight) => (
                     <li key={highlight} className="flex items-start gap-2">
                       <span
-                        className="mt-1 h-1.5 w-1.5 rounded-full bg-[var(--accent-amber)]"
+                        className="mt-1 h-1.5 w-1.5 rounded-full bg-[color:var(--accent-amber)]"
                         aria-hidden
                       />
                       <span>{highlight}</span>
@@ -260,17 +260,20 @@ export default function AboutPage() {
         </Container>
       </Section>
 
-      <Section tone="light" className="relative overflow-hidden py-24 text-[#1b0b0a]">
-        <div className="absolute inset-0 -z-10 bg-[#fdf1e4]" aria-hidden />
+      <Section className="relative overflow-hidden py-24">
+        <div
+          className="absolute inset-0 -z-10 bg-[radial-gradient(120%_160%_at_50%_0%,rgba(255,112,68,0.18),transparent_70%),linear-gradient(180deg,rgba(20,8,10,0.96),rgba(8,4,6,0.92))]"
+          aria-hidden
+        />
         <Container className="space-y-12">
           <div className="max-w-3xl space-y-5">
-            <span className="inline-flex items-center gap-2 rounded-full border border-[#ffb26b]/50 bg-[#ffb26b]/10 px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-[#7a2f16]">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
               Programme layers
             </span>
-            <h2 className="text-3xl font-black sm:text-4xl text-[#220d0c]">
+            <h2 className="text-3xl font-black sm:text-4xl">
               One backbone, three pillars of delivery.
             </h2>
-            <p className="text-base text-[#4c1f18] sm:text-lg">
+            <p className="text-base text-muted sm:text-lg">
               Each layer is anchored in the commitments we made across the eGovRegistry and digital
               platform programmes. Together they guarantee continuity, accountability, and care for
               the public.
@@ -285,10 +288,10 @@ export default function AboutPage() {
                 whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
                 transition={{ duration: 0.5, ease: 'easeOut', delay: index * 0.06 }}
-                className="flex h-full flex-col gap-4 rounded-[24px] border border-[#ffb26b]/40 bg-white/80 p-6 shadow-[0_24px_80px_rgba(125,63,34,0.18)] backdrop-blur"
+                className="surface-panel flex h-full flex-col gap-4 rounded-[24px] border border-[color:var(--border)] p-6"
               >
-                <h3 className="text-lg font-semibold text-[#2b0f0d]">{layer.title}</h3>
-                <p className="text-sm text-[#4f1f1a]">{layer.copy}</p>
+                <h3 className="text-lg font-semibold text-[color:var(--ink)]">{layer.title}</h3>
+                <p className="text-sm text-muted">{layer.copy}</p>
               </motion.article>
             ))}
           </div>
@@ -298,23 +301,23 @@ export default function AboutPage() {
       <Section className="relative overflow-hidden py-24">
         <div className="absolute inset-0 -z-10">
           <div
-            className="absolute left-[-20%] top-20 h-64 w-64 rounded-full bg-[radial-gradient(circle,rgba(255,110,64,0.18),transparent_70%)] blur-[120px]"
+            className="absolute left-[-20%] top-20 h-64 w-64 rounded-full bg-[radial-gradient(circle,rgba(255,108,68,0.18),transparent_70%)] blur-[120px]"
             aria-hidden
           />
           <div
-            className="absolute right-[-10%] bottom-10 h-72 w-72 rounded-full bg-[radial-gradient(circle,rgba(255,210,160,0.16),transparent_70%)] blur-[120px]"
+            className="absolute right-[-10%] bottom-10 h-72 w-72 rounded-full bg-[radial-gradient(circle,rgba(140,46,42,0.18),transparent_70%)] blur-[120px]"
             aria-hidden
           />
         </div>
         <Container className="space-y-12">
-          <div className="max-w-3xl space-y-5 text-white">
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/12 bg-white/10 px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-white/70">
+          <div className="max-w-3xl space-y-5">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
               How we operate
             </span>
             <h2 className="text-3xl font-black sm:text-4xl">
               Guardrails that keep programmes human, secure, and measurable.
             </h2>
-            <p className="text-base text-white/75 sm:text-lg">
+            <p className="text-base text-muted sm:text-lg">
               Beyond software delivery, we nurture the operating culture needed for change to stick.
               These principles guide every stand-up, every deployment, and every town-hall we
               facilitate.
@@ -328,26 +331,30 @@ export default function AboutPage() {
                 whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
                 transition={{ duration: 0.55, ease: 'easeOut', delay: index * 0.08 }}
-                className="flex h-full flex-col gap-4 rounded-[28px] border border-white/12 bg-[color:rgba(12,15,23,0.92)] p-8 shadow-[0_36px_110px_rgba(4,6,15,0.5)]"
+                className="surface-card flex h-full flex-col gap-4 rounded-[28px] border border-[color:var(--border)] p-8"
               >
-                <h3 className="text-xl font-semibold text-white">{principle.title}</h3>
-                <p className="text-sm text-white/75">{principle.detail}</p>
+                <h3 className="text-xl font-semibold text-[color:var(--ink)]">{principle.title}</h3>
+                <p className="text-sm text-muted">{principle.detail}</p>
               </motion.article>
             ))}
           </div>
         </Container>
       </Section>
 
-      <Section tone="light" className="bg-white py-24 text-[#0d1b2a]">
+      <Section className="relative overflow-hidden py-24">
+        <div
+          className="absolute inset-0 -z-10 bg-[radial-gradient(120%_160%_at_50%_0%,rgba(90,32,40,0.22),transparent_70%),linear-gradient(180deg,rgba(12,6,8,0.95),rgba(5,3,4,0.92))]"
+          aria-hidden
+        />
         <Container className="space-y-12">
           <div className="max-w-3xl space-y-5">
-            <span className="inline-flex items-center gap-2 rounded-full border border-[#cdd7e4] bg-[#e9eef6] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-[#3c526c]">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
               Our journey
             </span>
-            <h2 className="text-3xl font-black sm:text-4xl text-[#0f1d31]">
+            <h2 className="text-3xl font-black sm:text-4xl">
               Years of public digital work in one timeline.
             </h2>
-            <p className="text-base text-[#445369] sm:text-lg">
+            <p className="text-base text-muted sm:text-lg">
               Every milestone is tied to a partnership where citizens felt the difference. We keep
               those lessons alive across new mandates.
             </p>
@@ -360,13 +367,13 @@ export default function AboutPage() {
                 whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
                 transition={{ duration: 0.5, ease: 'easeOut', delay: index * 0.05 }}
-                className="flex h-full flex-col gap-3 rounded-[24px] border border-[#d8e2ef] bg-white p-6 shadow-[0_24px_80px_rgba(15,29,49,0.08)]"
+                className="surface-card flex h-full flex-col gap-3 rounded-[24px] border border-[color:var(--border)] p-6"
               >
-                <span className="text-xs font-semibold uppercase tracking-[0.32em] text-[#60728e]">
+                <span className="text-xs font-semibold uppercase tracking-[0.32em] text-muted">
                   {item.year}
                 </span>
-                <h3 className="text-lg font-semibold text-[#0f1d31]">{item.title}</h3>
-                <p className="text-sm text-[#445369]">{item.description}</p>
+                <h3 className="text-lg font-semibold text-[color:var(--ink)]">{item.title}</h3>
+                <p className="text-sm text-muted">{item.description}</p>
               </motion.li>
             ))}
           </ol>
@@ -376,19 +383,19 @@ export default function AboutPage() {
       <Section className="relative overflow-hidden py-24">
         <div className="absolute inset-0 -z-10">
           <div
-            className="absolute inset-x-0 top-[20%] h-48 bg-[radial-gradient(65%_140%_at_50%_0%,rgba(255,111,60,0.16),transparent_70%)]"
+            className="absolute inset-x-0 top-[20%] h-48 bg-[radial-gradient(65%_140%_at_50%_0%,rgba(255,112,68,0.18),transparent_70%)]"
             aria-hidden
           />
         </div>
-        <Container className="space-y-12 text-white">
+        <Container className="space-y-12">
           <div className="mx-auto max-w-4xl text-center">
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/12 bg-white/10 px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-white/70">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
               Inside Arctura
             </span>
             <h2 className="mt-6 text-3xl font-black sm:text-4xl">
               Multidisciplinary teams that stay in the arena with you.
             </h2>
-            <p className="mt-4 text-base text-white/75 sm:text-lg">
+            <p className="mt-4 text-base text-muted sm:text-lg">
               The same people who design resident journeys also review policy drafts, rehearse
               continuity drills, and brief cabinet members. We remain embedded until your teams can
               run independently.
@@ -402,7 +409,7 @@ export default function AboutPage() {
                 whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
                 viewport={{ once: true, amount: 0.3 }}
                 transition={{ duration: 0.55, ease: 'easeOut', delay: index * 0.08 }}
-                className="flex h-full flex-col overflow-hidden rounded-[28px] border border-white/12 bg-white/5"
+                className="surface-panel flex h-full flex-col overflow-hidden rounded-[28px] border border-[color:var(--border)]"
               >
                 <div className="relative h-60">
                   <Image
@@ -416,11 +423,11 @@ export default function AboutPage() {
                     className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/30 to-transparent"
                     aria-hidden
                   />
-                  <figcaption className="absolute bottom-4 left-4 text-sm font-semibold uppercase tracking-[0.32em] text-white/80">
+                  <figcaption className="absolute bottom-4 left-4 text-sm font-semibold uppercase tracking-[0.32em] text-[color:var(--glacier)]/80">
                     {scene.label}
                   </figcaption>
                 </div>
-                <p className="p-6 text-sm text-white/75">{scene.caption}</p>
+                <p className="p-6 text-sm text-muted">{scene.caption}</p>
               </motion.figure>
             ))}
           </div>
@@ -429,12 +436,12 @@ export default function AboutPage() {
             whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
             viewport={{ once: true, amount: 0.3 }}
             transition={{ duration: 0.6, ease: 'easeOut', delay: 0.2 }}
-            className="mx-auto flex max-w-3xl flex-col items-center rounded-[32px] border border-white/12 bg-[linear-gradient(120deg,rgba(12,15,23,0.95),rgba(255,111,60,0.2))] p-10 text-center shadow-[0_40px_120px_rgba(4,6,15,0.55)]"
+            className="mx-auto flex max-w-3xl flex-col items-center rounded-[32px] border border-[color:var(--border)] bg-[linear-gradient(125deg,rgba(24,12,16,0.95),rgba(10,5,8,0.9))] p-10 text-center shadow-[0_40px_120px_rgba(6,3,5,0.6)]"
           >
-            <h3 className="text-2xl font-semibold text-white md:text-3xl">
+            <h3 className="text-2xl font-semibold text-[color:var(--ink)] md:text-3xl">
               Ready to design the next chapter of your public digital infrastructure?
             </h3>
-            <p className="mt-4 text-sm text-white/75 sm:text-base">
+            <p className="mt-4 text-sm text-muted sm:text-base">
               Share your mission and constraints. We will assemble an Arctura squad that blends
               registry, platform, and change expertise tailored to your mandate.
             </p>
@@ -442,7 +449,7 @@ export default function AboutPage() {
               asChild
               variant="gradient"
               shape="pill"
-              className="mt-6 h-12 items-center gap-3 rounded-full px-7 text-sm font-semibold uppercase tracking-[0.3em] text-black"
+              className="mt-6 h-12 items-center gap-3 rounded-full px-7 text-sm font-semibold uppercase tracking-[0.3em]"
             >
               <a href="/contact">Start a conversation</a>
             </Button>

--- a/src/app/careers/[slug]/page.tsx
+++ b/src/app/careers/[slug]/page.tsx
@@ -16,7 +16,7 @@ export default async function RolePage({ params }: { params: Promise<{ slug: str
   const role = await getRole(slug)
   if (!role) notFound()
   return (
-    <main id="content">
+    <main id="content" className="bg-[color:var(--bg)] text-[color:var(--fg)]">
       <Section>
         <Container>
           <BreadcrumbJsonLd

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -8,7 +8,7 @@ import { HoverLift } from '@/components/hover-lift'
 export default async function CareersPage() {
   const roles = await getRoles()
   return (
-    <main id="content">
+    <main id="content" className="bg-[color:var(--bg)] text-[color:var(--fg)]">
       <Section>
         <Container>
           <SectionHeader
@@ -20,17 +20,20 @@ export default async function CareersPage() {
               <HoverLift key={r.slug}>
                 <Link
                   href={`/careers/${r.slug}`}
-                  className="rounded-xl border border-white/10 bg-white/5 p-6 hover:bg-white/[0.08]"
+                  className="surface-card rounded-3xl border border-[color:var(--border)] p-6 transition hover:-translate-y-0.5"
                 >
-                  <h3 className="text-lg font-semibold">{r.title}</h3>
-                  <p className="text-sm text-slate-400">{r.location} • {r.type}</p>
-                  <p className="mt-2 text-slate-300">{r.summary}</p>
+                  <h3 className="text-lg font-semibold text-[color:var(--ink)]">{r.title}</h3>
+                  <p className="text-sm text-muted">{r.location} • {r.type}</p>
+                  <p className="mt-2 text-muted">{r.summary}</p>
                 </Link>
               </HoverLift>
             ))}
           </div>
-          <p className="mt-8 text-slate-300">
-            Don’t see a perfect fit? <a className="underline" href="#apply">Send us your CV</a>
+          <p className="mt-8 text-muted">
+            Don’t see a perfect fit?{' '}
+            <a className="underline" href="#apply">
+              Send us your CV
+            </a>
           </p>
         </Container>
       </Section>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -33,7 +33,7 @@ export default function ContactPage() {
   }
 
   return (
-    <main id="content">
+    <main id="content" className="bg-[color:var(--bg)] text-[color:var(--fg)]">
       <Section>
         <Container>
           <SectionHeader title="Contact us" subtitle="We typically respond within one business day." />
@@ -41,24 +41,24 @@ export default function ContactPage() {
             onSubmit={handleSubmit(onSubmit)}
             action="/api/contact"
             method="post"
-            className="grid gap-4 rounded-xl border border-white/10 bg-white/5 p-6 md:grid-cols-2"
+            className="grid gap-4 rounded-3xl border border-[color:var(--border)] bg-[color:var(--surface)] p-6 shadow-soft md:grid-cols-2"
           >
             <label className="grid gap-1">
-              <span className="text-sm">Name</span>
+              <span className="text-sm text-muted-strong">Name</span>
               <Input placeholder="Ada Lovelace" aria-invalid={!!errors.name} aria-describedby={errors.name ? 'name-error' : undefined} {...register('name')} />
               {errors.name && <span id="name-error" className="text-sm text-red-400">{errors.name.message}</span>}
             </label>
             <label className="grid gap-1">
-              <span className="text-sm">Email</span>
+              <span className="text-sm text-muted-strong">Email</span>
               <Input type="email" placeholder="you@company.com" aria-invalid={!!errors.email} aria-describedby={errors.email ? 'email-error' : undefined} {...register('email')} />
               {errors.email && <span id="email-error" className="text-sm text-red-400">{errors.email.message}</span>}
             </label>
             <label className="grid gap-1 md:col-span-2">
-              <span className="text-sm">Company</span>
+              <span className="text-sm text-muted-strong">Company</span>
               <Input placeholder="Acme Inc." {...register('company')} />
             </label>
             <label className="grid gap-1 md:col-span-2">
-              <span className="text-sm">How can we help?</span>
+              <span className="text-sm text-muted-strong">How can we help?</span>
               <Textarea rows={5} placeholder="Tell us about your goals" aria-invalid={!!errors.message} aria-describedby={errors.message ? 'message-error' : undefined} {...register('message')} />
               {errors.message && (
                 <span id="message-error" className="text-sm text-red-400">{errors.message.message as string}</span>
@@ -73,12 +73,12 @@ export default function ContactPage() {
                 {isSubmitting ? 'Sending…' : 'Send message'}
               </Button>
               {isSubmitSuccessful && (
-                <span className="ml-3 text-sm text-green-400">Thanks — we’ll be in touch.</span>
+                <span className="ml-3 text-sm text-muted">Thanks — we’ll be in touch.</span>
               )}
               {serverError && <span className="ml-3 text-sm text-red-400">{serverError}</span>}
             </div>
           </form>
-          <p className="mt-6 text-sm text-slate-400">
+          <p className="mt-6 text-sm text-muted">
             Prefer email? hello@arctura-analytics.com • We keep your data private and only use it to
             respond to your inquiry.
           </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,7 +41,7 @@ export const dynamic = 'force-static'
 
 export default function HomePage() {
   return (
-    <main id="content" className="bg-[#040203] text-white">
+    <main id="content" className="bg-[color:var(--bg)] text-[color:var(--fg)]">
       <section className="relative isolate overflow-hidden">
         <Image
           src="/brand/georgie-cobbs-muOHbrFGEQY-unsplash.jpg"
@@ -52,33 +52,33 @@ export default function HomePage() {
           className="object-cover"
         />
         <div
-          className="absolute inset-0 bg-[radial-gradient(circle_at_10%_-10%,rgba(255,111,60,0.45),transparent_45%),radial-gradient(circle_at_90%_10%,rgba(255,64,64,0.25),transparent_55%),linear-gradient(to_bottom,#040203,rgba(4,2,3,0.92),#06040a)]"
+          className="absolute inset-0 bg-[radial-gradient(circle_at_12%_-10%,rgba(255,100,60,0.32),transparent_45%),radial-gradient(circle_at_88%_8%,rgba(177,45,40,0.22),transparent_55%),linear-gradient(to_bottom,#050203,rgba(6,3,4,0.92),#040203)]"
           aria-hidden
         />
-        <ParticleField className="absolute inset-0 opacity-35" aria-hidden />
+        <ParticleField className="absolute inset-0 opacity-30" aria-hidden />
         <Container className="relative z-[1] flex min-h-[90vh] flex-col justify-center gap-12 py-24">
           <div className="max-w-3xl space-y-6">
-            <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-white/70">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
               Arctura Analytics
             </span>
             <h1 className="text-balance text-4xl font-black leading-tight sm:text-5xl lg:text-6xl">
               Ignite conviction with data platforms forged for critical missions.
             </h1>
-            <p className="max-w-2xl text-lg text-white/70">
+            <p className="max-w-2xl text-lg text-muted">
               We transform fragmented civic systems into living, intelligent infrastructures—quietly powerful,
               fiercely secure, and ready for the next mandate.
             </p>
             <div className="flex flex-wrap gap-4">
               <Link
                 href="/contact"
-                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-[#ff7b39] via-[#ff5a36] to-[#ffb347] px-6 py-3 text-sm font-semibold uppercase tracking-[0.32em] text-black shadow-[0_22px_60px_rgba(255,91,54,0.45)] transition hover:-translate-y-0.5"
+                className="inline-flex items-center gap-2 rounded-full bg-[linear-gradient(120deg,var(--accent-start),var(--accent-mid),var(--accent-end))] px-6 py-3 text-sm font-semibold uppercase tracking-[0.32em] text-[#1a0505] shadow-[0_22px_64px_rgba(255,100,60,0.4)] transition hover:-translate-y-0.5 hover:shadow-[0_26px_74px_rgba(255,100,60,0.46)]"
               >
                 Start a project
                 <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
               </Link>
               <Link
                 href="/about"
-                className="inline-flex items-center gap-2 rounded-full border border-white/20 px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-white/70 transition hover:border-white/50 hover:text-white"
+                className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] px-6 py-3 text-sm font-semibold uppercase tracking-[0.3em] text-muted transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--ink)]"
               >
                 Discover our story
               </Link>
@@ -88,10 +88,10 @@ export default function HomePage() {
             {heroStats.map((stat) => (
               <div
                 key={stat.label}
-                className="rounded-3xl border border-white/10 bg-white/5 p-5 text-white/70 backdrop-blur"
+                className="surface-card rounded-3xl p-5 text-muted transition"
               >
-                <div className="text-2xl font-semibold text-white">{stat.value}</div>
-                <div className="mt-2 text-xs uppercase tracking-[0.28em]">{stat.label}</div>
+                <div className="text-2xl font-semibold text-[color:var(--ink)]">{stat.value}</div>
+                <div className="mt-2 text-xs uppercase tracking-[0.28em] text-muted">{stat.label}</div>
               </div>
             ))}
           </div>
@@ -99,20 +99,20 @@ export default function HomePage() {
       </section>
 
       <Section className="relative overflow-hidden py-24">
-        <div className="pointer-events-none absolute inset-0 -z-10 opacity-80">
+        <div className="pointer-events-none absolute inset-0 -z-10 opacity-70">
           <div
-            className="absolute inset-x-0 top-0 h-40 bg-[radial-gradient(70%_120%_at_50%_-10%,rgba(255,84,61,0.35),transparent_70%)]"
+            className="absolute inset-x-0 top-0 h-40 bg-[radial-gradient(70%_120%_at_50%_-10%,rgba(255,108,68,0.24),transparent_70%)]"
             aria-hidden
           />
           <div
-            className="absolute inset-x-0 bottom-0 h-32 bg-[radial-gradient(60%_120%_at_50%_120%,rgba(255,110,60,0.18),transparent_70%)]"
+            className="absolute inset-x-0 bottom-0 h-32 bg-[radial-gradient(60%_120%_at_50%_120%,rgba(177,45,40,0.16),transparent_70%)]"
             aria-hidden
           />
         </div>
         <Container className="space-y-12">
           <div className="max-w-2xl space-y-5">
             <h2 className="text-3xl font-black sm:text-4xl">Strategy shaped in the crucible.</h2>
-            <p className="text-base text-white/70 sm:text-lg">
+            <p className="text-base text-muted sm:text-lg">
               Every programme is engineered to withstand scrutiny, scale gracefully, and elevate the people it
               serves. We keep the story simple so the impact can be profound.
             </p>
@@ -120,10 +120,10 @@ export default function HomePage() {
           <div className="grid gap-6 md:grid-cols-3">
             {commitments.map((item) => (
               <HoverLift key={item.title}>
-                <div className="h-full rounded-[28px] border border-white/12 bg-[color:rgba(12,7,14,0.92)] p-7 shadow-[0_40px_120px_rgba(11,4,9,0.65)] transition">
-                  <item.icon className="h-8 w-8 text-[#ff8254]" aria-hidden />
-                  <h3 className="mt-4 text-lg font-semibold text-white">{item.title}</h3>
-                  <p className="mt-2 text-sm text-white/70">{item.description}</p>
+                <div className="surface-card h-full rounded-[28px] border border-[color:var(--border)] p-7 transition">
+                  <item.icon className="h-8 w-8 text-[color:var(--accent-amber)]" aria-hidden />
+                  <h3 className="mt-4 text-lg font-semibold text-[color:var(--ink)]">{item.title}</h3>
+                  <p className="mt-2 text-sm text-muted">{item.description}</p>
                 </div>
               </HoverLift>
             ))}
@@ -134,54 +134,54 @@ export default function HomePage() {
       <Section className="relative overflow-hidden py-24">
         <div className="pointer-events-none absolute inset-0 -z-10">
           <div
-            className="absolute left-[-15%] top-12 h-72 w-72 rounded-full bg-[radial-gradient(circle,rgba(255,122,63,0.22),transparent_68%)] blur-[120px]"
+            className="absolute left-[-15%] top-12 h-72 w-72 rounded-full bg-[radial-gradient(circle,rgba(255,112,70,0.22),transparent_68%)] blur-[120px]"
             aria-hidden
           />
           <div
-            className="absolute right-[-12%] bottom-8 h-72 w-72 rounded-full bg-[radial-gradient(circle,rgba(255,182,122,0.18),transparent_70%)] blur-[120px]"
+            className="absolute right-[-12%] bottom-8 h-72 w-72 rounded-full bg-[radial-gradient(circle,rgba(150,48,44,0.18),transparent_70%)] blur-[120px]"
             aria-hidden
           />
         </div>
 
         <Container>
-          <div className="grid gap-10 rounded-[40px] border border-white/12 bg-[linear-gradient(135deg,rgba(8,5,10,0.92),rgba(55,20,12,0.68))] p-8 shadow-[0_50px_160px_rgba(8,3,7,0.65)] backdrop-blur lg:grid-cols-[0.9fr_1.1fr] lg:p-14">
+          <div className="grid gap-10 rounded-[40px] border border-[color:var(--border)] bg-[linear-gradient(140deg,rgba(20,10,14,0.92),rgba(8,4,6,0.9))] p-8 shadow-[0_50px_160px_rgba(8,3,6,0.66)] backdrop-blur lg:grid-cols-[0.9fr_1.1fr] lg:p-14">
             <div className="space-y-6">
-              <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-white/70">
+              <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
                 Begin the ascent
               </span>
-              <h2 className="text-3xl font-black text-white sm:text-4xl">
+              <h2 className="text-3xl font-black text-[color:var(--ink)] sm:text-4xl">
                 Let’s channel your next mandate into momentum.
               </h2>
-              <p className="text-base text-white/70 sm:text-lg">
+              <p className="text-base text-muted sm:text-lg">
                 Share the challenges in front of you. We respond with a tailored path, clear governance, and the
                 team who will stand with you from spark to sustained impact.
               </p>
-              <div className="flex flex-wrap gap-3 text-sm text-white/60">
-                <span className="rounded-full border border-white/20 px-4 py-2 uppercase tracking-[0.32em]">
+              <div className="flex flex-wrap gap-3 text-sm text-muted">
+                <span className="rounded-full border border-[color:var(--border)] px-4 py-2 uppercase tracking-[0.32em]">
                   Discovery in 10 days
                 </span>
-                <span className="rounded-full border border-white/20 px-4 py-2 uppercase tracking-[0.32em]">
+                <span className="rounded-full border border-[color:var(--border)] px-4 py-2 uppercase tracking-[0.32em]">
                   Policy-ready roadmaps
                 </span>
-                <span className="rounded-full border border-white/20 px-4 py-2 uppercase tracking-[0.32em]">
+                <span className="rounded-full border border-[color:var(--border)] px-4 py-2 uppercase tracking-[0.32em]">
                   On-site + remote squads
                 </span>
               </div>
               <Link
                 href="/careers"
-                className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.3em] text-white/60 transition hover:text-white"
+                className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.3em] text-muted transition hover:text-[color:var(--ink)]"
               >
                 Meet the people behind the work
                 <ArrowUpRight className="h-4 w-4" aria-hidden />
               </Link>
             </div>
 
-            <div className="space-y-6 rounded-[28px] border border-white/10 bg-[linear-gradient(120deg,rgba(18,10,18,0.78),rgba(255,119,70,0.18))] p-8 shadow-[0_36px_110px_rgba(10,4,9,0.55)] lg:border-l lg:border-white/15 lg:pl-12">
-              <h3 className="text-2xl font-semibold text-white">Plan a consultation.</h3>
-              <p className="text-sm text-white/70 sm:text-base">
+            <div className="surface-panel space-y-6 rounded-[28px] border border-[color:var(--border)] p-8 shadow-[0_36px_110px_rgba(8,3,6,0.55)] lg:border-l lg:pl-12">
+              <h3 className="text-2xl font-semibold text-[color:var(--ink)]">Plan a consultation.</h3>
+              <p className="text-sm text-muted sm:text-base">
                 Outline your objectives and timeframes—we will align the specialists and spark the engagement.
               </p>
-              <div className="grid gap-3 text-[0.68rem] uppercase tracking-[0.32em] text-white/50 sm:text-xs">
+              <div className="grid gap-3 text-[0.68rem] uppercase tracking-[0.32em] text-muted sm:text-xs">
                 <span className="flex items-center gap-2">↗︎ Executive alignment in week one</span>
                 <span className="flex items-center gap-2">↗︎ Delivery blueprint within 30 days</span>
               </div>

--- a/src/components/apply-form.tsx
+++ b/src/components/apply-form.tsx
@@ -21,25 +21,25 @@ export function ApplyForm() {
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
-      className="grid gap-4 rounded-xl border border-white/10 bg-white/5 p-6 md:grid-cols-2"
+      className="grid gap-4 rounded-3xl border border-[color:var(--border)] bg-[color:var(--surface)] p-6 shadow-soft md:grid-cols-2"
     >
       <label className="grid gap-1">
-        <span className="text-sm">Full name</span>
+        <span className="text-sm text-muted-strong">Full name</span>
         <Input placeholder="Ada Lovelace" aria-invalid={!!errors.name} aria-describedby={errors.name ? 'apply-name-error' : undefined} {...register('name')} />
         {errors.name && <span id="apply-name-error" className="text-sm text-red-400">{errors.name.message}</span>}
       </label>
       <label className="grid gap-1">
-        <span className="text-sm">Email</span>
+        <span className="text-sm text-muted-strong">Email</span>
         <Input type="email" placeholder="you@company.com" aria-invalid={!!errors.email} aria-describedby={errors.email ? 'apply-email-error' : undefined} {...register('email')} />
         {errors.email && <span id="apply-email-error" className="text-sm text-red-400">{errors.email.message}</span>}
       </label>
       <label className="grid gap-1 md:col-span-2">
-        <span className="text-sm">CV URL</span>
+        <span className="text-sm text-muted-strong">CV URL</span>
         <Input placeholder="https://link-to-your-cv.pdf" aria-invalid={!!errors.cv} aria-describedby={errors.cv ? 'apply-cv-error' : undefined} {...register('cv')} />
         {errors.cv && <span id="apply-cv-error" className="text-sm text-red-400">{errors.cv.message as string}</span>}
       </label>
       <label className="grid gap-1 md:col-span-2">
-        <span className="text-sm">Message</span>
+        <span className="text-sm text-muted-strong">Message</span>
         <Textarea rows={5} placeholder="Tell us why you’re excited" aria-invalid={!!errors.message} aria-describedby={errors.message ? 'apply-message-error' : undefined} {...register('message')} />
         {errors.message && (
           <span id="apply-message-error" className="text-sm text-red-400">{errors.message.message as string}</span>
@@ -50,7 +50,7 @@ export function ApplyForm() {
           {isSubmitting ? 'Submitting…' : 'Submit application'}
         </Button>
         {isSubmitSuccessful && (
-          <span className="ml-3 text-sm text-green-400">Thanks — we’ll be in touch.</span>
+          <span className="ml-3 text-sm text-muted">Thanks — we’ll be in touch.</span>
         )}
       </div>
     </form>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,28 +4,34 @@ import { Logo } from './logo'
 
 export function Footer() {
   return (
-    <footer className="border-t border-white/10 py-10">
+    <footer className="border-t border-[color:var(--border)] py-10">
       <Container className="flex flex-col items-center justify-between gap-6 md:flex-row">
         <Link href="/" className="flex items-center gap-2 transition-opacity hover:opacity-90">
           <Logo size={24} showText={false} variant="light" withLink={false} />
-          <span className="text-sm bg-gradient-to-r from-[#ff7b39] via-[#ff8a47] to-[#ffb347] bg-clip-text text-transparent font-medium">
+          <span className="text-sm font-medium text-muted">
             Arctura Analytics Limited
           </span>
         </Link>
-        <nav className="text-sm text-slate-400">
+        <nav className="text-sm text-muted">
           <ul className="flex items-center gap-4">
             <li>
-              <Link href="/about">About</Link>
+              <Link href="/about" className="hover:text-[color:var(--ink)]">
+                About
+              </Link>
             </li>
             <li>
-              <Link href="/careers">Careers</Link>
+              <Link href="/careers" className="hover:text-[color:var(--ink)]">
+                Careers
+              </Link>
             </li>
             <li>
-              <Link href="/contact">Contact</Link>
+              <Link href="/contact" className="hover:text-[color:var(--ink)]">
+                Contact
+              </Link>
             </li>
           </ul>
         </nav>
-        <p className="text-xs text-slate-500">
+        <p className="text-xs text-muted">
           {'\u00A9'} {new Date().getFullYear()} Arctura Analytics Limited
         </p>
       </Container>

--- a/src/components/forms/fields.tsx
+++ b/src/components/forms/fields.tsx
@@ -7,7 +7,7 @@ export const Input = forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTML
     <input
       ref={ref}
       className={cn(
-        'w-full rounded-md border border-white/10 bg-black/20 px-3 py-2 outline-none placeholder:text-slate-400 focus:border-white/30',
+        'w-full rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-3 py-2 text-[color:var(--fg)] outline-none placeholder:text-muted focus:border-[color:var(--border-strong)] focus:ring-0 focus-visible:ring-2 focus-visible:ring-[color:var(--border-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]',
         className
       )}
       {...props}
@@ -21,7 +21,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttrib
     <textarea
       ref={ref}
       className={cn(
-        'w-full rounded-md border border-white/10 bg-black/20 px-3 py-2 outline-none placeholder:text-slate-400 focus:border-white/30',
+        'w-full rounded-xl border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-3 py-2 text-[color:var(--fg)] outline-none placeholder:text-muted focus:border-[color:var(--border-strong)] focus:ring-0 focus-visible:ring-2 focus-visible:ring-[color:var(--border-strong)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]',
         className
       )}
       {...props}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -47,14 +47,14 @@ export function Header() {
       className={clsx(
         'sticky top-0 z-50 w-full border-b border-transparent transition-all duration-200 ease-out',
         isScrolled
-          ? 'border-white/10 bg-[#050508]/90 shadow-[0_8px_24px_rgba(2,6,23,0.35)] backdrop-blur-lg'
+          ? 'border-[color:var(--border)] bg-[color:rgba(10,5,7,0.9)] shadow-[0_8px_24px_rgba(6,3,5,0.55)] backdrop-blur-lg'
           : 'bg-transparent'
       )}
     >
       <Container className="flex h-16 items-center justify-between gap-4 md:h-20">
         <Link
           href="/"
-          className="flex items-center gap-3 text-white"
+          className="flex items-center gap-3 text-[color:var(--ink)]"
           aria-label="Arctura Analytics home"
         >
           <Logo size={36} withLink={false} showText={true} textClassName="text-lg font-bold tracking-wider" />
@@ -62,7 +62,7 @@ export function Header() {
 
         {/* Desktop nav */}
         <nav
-          className="hidden items-center gap-1 rounded-full bg-white/5 p-1 text-sm text-white/70 md:flex"
+          className="hidden items-center gap-1 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)]/80 p-1 text-sm text-muted md:flex"
           aria-label="Primary"
         >
           {mainNav.map((item) => (
@@ -70,15 +70,15 @@ export function Header() {
               key={item.href}
               href={item.href}
               className={clsx(
-                'relative inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium transition-colors duration-150 hover:text-white',
-                isActive(item.href) && 'text-white'
+                'relative inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium transition-colors duration-150 hover:text-[color:var(--ink)]',
+                isActive(item.href) && 'text-[color:var(--ink)]'
               )}
               aria-current={isActive(item.href) ? 'page' : undefined}
             >
               <span
                 aria-hidden="true"
                 className={clsx(
-                  'absolute inset-y-1 left-1 right-1 rounded-full bg-gradient-to-r from-brand-400/0 via-orange-400/10 to-brand-400/0 opacity-0 transition-opacity duration-150',
+                  'absolute inset-y-1 left-1 right-1 rounded-full bg-[linear-gradient(120deg,var(--accent-start),var(--accent-mid),var(--accent-end))] opacity-0 transition-opacity duration-150',
                   isActive(item.href) && 'opacity-100'
                 )}
               />
@@ -91,7 +91,7 @@ export function Header() {
         <div className="flex items-center gap-2">
           <Link
             href="/contact"
-            className="inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-orange-400 via-brand-400 to-orange-500 px-4 py-2 text-sm font-semibold text-[#d5d5f7] shadow-[0_14px_32px_rgba(255,110,64,0.35)] transition-transform hover:-translate-y-0.5"
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-[linear-gradient(120deg,var(--accent-start),var(--accent-mid),var(--accent-end))] px-4 py-2 text-sm font-semibold text-[#1a0505] shadow-[0_18px_48px_rgba(255,100,60,0.32)] transition-transform hover:-translate-y-0.5 hover:shadow-[0_22px_60px_rgba(255,100,60,0.4)]"
           >
             <PhoneCall className="h-4 w-4" aria-hidden="true" />
             Talk to us
@@ -99,7 +99,7 @@ export function Header() {
 
           <button
             type="button"
-            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/15 text-white transition hover:border-white/40 hover:text-white md:hidden"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[color:var(--border)] text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--ink)] md:hidden"
             aria-label={isMobileOpen ? 'Close menu' : 'Open menu'}
             aria-expanded={isMobileOpen}
             onClick={() => setIsMobileOpen((v) => !v)}
@@ -111,7 +111,7 @@ export function Header() {
 
       {/* Mobile drawer */}
       {isMobileOpen && (
-        <div className="border-t border-white/10 bg-[#050508]/98 backdrop-blur md:hidden">
+        <div className="border-t border-[color:var(--border)] bg-[color:rgba(6,3,5,0.98)] backdrop-blur md:hidden">
           <Container className="flex flex-col gap-6 py-6">
             <nav className="flex flex-col gap-2" aria-label="Mobile">
               {mainNav.map((item) => (
@@ -119,8 +119,8 @@ export function Header() {
                   key={item.href}
                   href={item.href}
                   className={clsx(
-                    'block rounded-xl px-4 py-3 text-base font-medium text-white/80 transition-colors hover:bg-white/5 hover:text-white',
-                    isActive(item.href) && 'bg-white/5 text-white'
+                    'block rounded-xl px-4 py-3 text-base font-medium text-muted transition-colors hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--ink)]',
+                    isActive(item.href) && 'bg-[color:var(--surface-muted)] text-[color:var(--ink)]'
                   )}
                 >
                   {item.label}
@@ -130,7 +130,7 @@ export function Header() {
             <div className="flex flex-col gap-2">
               <Link
                 href="/contact"
-                className="block rounded-xl bg-gradient-to-r from-orange-400 via-brand-400 to-orange-500 px-4 py-3 text-center text-base font-semibold text-[#050508] transition hover:brightness-110"
+                className="block rounded-xl bg-[linear-gradient(120deg,var(--accent-start),var(--accent-mid),var(--accent-end))] px-4 py-3 text-center text-base font-semibold text-[#1a0505] transition hover:brightness-110"
               >
                 Talk to us
               </Link>

--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -11,7 +11,9 @@ export function Section({ className, bleed = false, tone = 'dark', children, ...
     <section
       className={cn(
         bleed ? '' : 'py-16 md:py-24',
-        tone === 'light' ? 'bg-white text-[#0D1B2A]' : '',
+        tone === 'light'
+          ? 'bg-[linear-gradient(135deg,rgba(40,19,22,0.92),rgba(15,6,8,0.92))] text-[color:var(--fg)]'
+          : 'text-[color:var(--fg)]',
         className
       )}
       {...props}
@@ -24,8 +26,8 @@ export function Section({ className, bleed = false, tone = 'dark', children, ...
 export function SectionHeader({ title, subtitle }: { title: string; subtitle?: string }) {
   return (
     <div className="mx-auto mb-10 max-w-2xl text-center">
-      <h2 className="text-3xl font-semibold md:text-4xl">{title}</h2>
-      {subtitle ? <p className="mt-4 text-slate-300">{subtitle}</p> : null}
+      <h2 className="text-3xl font-semibold text-[color:var(--ink)] md:text-4xl">{title}</h2>
+      {subtitle ? <p className="mt-4 text-muted">{subtitle}</p> : null}
     </div>
   )
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,10 +9,12 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: 'rounded-md bg-white text-black hover:opacity-90',
-        gradient: 'rounded-full text-[var(--glacier)] gradient hover:opacity-95',
-        coral: 'rounded-full text-white bg-[linear-gradient(90deg,var(--accent-teal),var(--accent-emerald),var(--accent-cyan))] hover:opacity-95 shadow-brand',
-        outline: 'rounded-full border border-white/30 text-white/90 hover:bg-white/5',
-        ghost: 'rounded-md hover:bg-white/5'
+        gradient:
+          'rounded-full text-[var(--glacier)] bg-[linear-gradient(120deg,var(--accent-start),var(--accent-mid),var(--accent-end))] shadow-[0_18px_48px_rgba(255,100,60,0.32)] transition-transform hover:-translate-y-0.5 hover:shadow-[0_22px_60px_rgba(255,100,60,0.36)]',
+        coral:
+          'rounded-full text-[var(--glacier)] bg-[linear-gradient(120deg,var(--accent-start),var(--accent-mid),var(--accent-end))] shadow-[0_16px_40px_rgba(255,100,60,0.28)] hover:-translate-y-0.5 hover:shadow-[0_20px_54px_rgba(255,100,60,0.34)]',
+        outline: 'rounded-full border border-[color:var(--border)] text-[color:var(--fg)] hover:bg-[color:rgba(26,13,18,0.35)]',
+        ghost: 'rounded-md hover:bg-[color:rgba(26,13,18,0.32)]'
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,70 +4,76 @@
 
 /* Brand palette */
 :root {
-  --bg: #050506;
-  --bg-alt: #090a0f;
-  --bg-gradient: radial-gradient(120% 160% at 50% 0%, rgba(109, 16, 32, 0.42) 0%, rgba(18, 19, 27, 0.92) 55%, #050506 100%);
-  --fg: #f5f6f9;
-  --ink: #ffffff;
-  --surface: rgba(15, 17, 25, 0.94);
-  --surface-elevated: rgba(18, 20, 30, 0.92);
-  --surface-muted: rgba(10, 11, 18, 0.9);
-  --border: rgba(255, 255, 255, 0.08);
-  --border-strong: rgba(255, 111, 60, 0.45);
-  --muted: #b5b9ca;
-  --muted-strong: #d0d3e0;
-  --accent-amber: #ff6f3c;
-  --accent-ember: #d72638;
-  --accent-crimson: #ff3d2e;
-  --accent-ember-soft: rgba(215, 38, 56, 0.22);
-  --accent-gradient: linear-gradient(120deg, #ff6f3c 0%, #ff3d2e 52%, #d72638 100%);
-  --glow-ember: 0 0 60px rgba(255, 111, 60, 0.28);
-  --glow-crimson: 0 0 70px rgba(215, 38, 56, 0.28);
-  --shadow-soft: 0 30px 90px rgba(4, 5, 12, 0.75);
+  --bg: #050203;
+  --bg-alt: #0a0507;
+  --bg-gradient: radial-gradient(135% 185% at 50% -20%, rgba(92, 24, 20, 0.5) 0%, rgba(20, 10, 13, 0.94) 52%, #050203 100%);
+  --fg: #f3eeef;
+  --ink: #fff9f7;
+  --surface: rgba(20, 11, 14, 0.94);
+  --surface-elevated: rgba(26, 13, 18, 0.94);
+  --surface-muted: rgba(13, 7, 10, 0.9);
+  --border: rgba(255, 117, 72, 0.16);
+  --border-strong: rgba(255, 124, 80, 0.45);
+  --muted: #c7b7b8;
+  --muted-strong: #e0d1d2;
+  --accent-start: #ff6434;
+  --accent-mid: #f13a33;
+  --accent-end: #b6212d;
+  --accent-amber: #ff6434;
+  --accent-ember: #f13a33;
+  --accent-crimson: #b6212d;
+  --accent-ember-soft: rgba(177, 49, 43, 0.22);
+  --accent-gradient: linear-gradient(125deg, var(--accent-start) 0%, var(--accent-mid) 52%, var(--accent-end) 100%);
+  --glow-ember: 0 0 58px rgba(255, 110, 70, 0.28);
+  --glow-crimson: 0 0 70px rgba(177, 49, 43, 0.32);
+  --shadow-soft: 0 34px 110px rgba(4, 3, 6, 0.72);
 
   /* Legacy aliases */
-  --bistre: #151620;
-  --smoky-black: #050506;
-  --space-cadet: #131420;
-  --lion: #ff6f3c;
-  --raisin-black: #0d0e15;
-  --accent-teal: #ff6f3c;
-  --accent-emerald: #ff3d2e;
-  --accent-cyan: #d72638;
-  --glacier: #fff4ed;
+  --bistre: #1a0d11;
+  --smoky-black: #050203;
+  --space-cadet: #140a12;
+  --lion: #ff6434;
+  --raisin-black: #0c0508;
+  --accent-teal: #ff6434;
+  --accent-emerald: #f13a33;
+  --accent-cyan: #b6212d;
+  --glacier: #fff2ea;
 }
 
 .dark {
-  --bg: #030304;
-  --bg-alt: #08080d;
-  --bg-gradient: radial-gradient(115% 150% at 50% 5%, rgba(102, 15, 30, 0.46) 0%, rgba(14, 15, 23, 0.94) 45%, #020203 100%);
-  --fg: #f4f5f8;
-  --ink: #ffffff;
-  --surface: rgba(14, 16, 25, 0.94);
-  --surface-elevated: rgba(17, 19, 28, 0.92);
-  --surface-muted: rgba(9, 10, 16, 0.9);
-  --border: rgba(255, 255, 255, 0.08);
-  --border-strong: rgba(255, 99, 52, 0.38);
-  --muted: #b5b8c7;
-  --muted-strong: #d0d3e0;
-  --accent-amber: #ff6f3c;
-  --accent-ember: #d72638;
-  --accent-crimson: #ff3d2e;
-  --accent-ember-soft: rgba(215, 38, 56, 0.24);
-  --accent-gradient: linear-gradient(120deg, #ff6f3c 0%, #ff3d2e 52%, #d72638 100%);
-  --glow-ember: 0 0 66px rgba(255, 111, 60, 0.32);
-  --glow-crimson: 0 0 74px rgba(215, 38, 56, 0.3);
-  --shadow-soft: 0 28px 88px rgba(0, 0, 0, 0.78);
+  --bg: #040103;
+  --bg-alt: #080307;
+  --bg-gradient: radial-gradient(130% 180% at 50% -15%, rgba(85, 19, 18, 0.52) 0%, rgba(18, 9, 12, 0.95) 48%, #040103 100%);
+  --fg: #f5f1f2;
+  --ink: #fff9f7;
+  --surface: rgba(18, 9, 12, 0.94);
+  --surface-elevated: rgba(23, 11, 15, 0.94);
+  --surface-muted: rgba(11, 6, 8, 0.9);
+  --border: rgba(255, 117, 72, 0.16);
+  --border-strong: rgba(255, 124, 80, 0.45);
+  --muted: #cbbcbc;
+  --muted-strong: #e3d6d6;
+  --accent-start: #ff6434;
+  --accent-mid: #f13a33;
+  --accent-end: #b6212d;
+  --accent-amber: #ff6434;
+  --accent-ember: #f13a33;
+  --accent-crimson: #b6212d;
+  --accent-ember-soft: rgba(177, 49, 43, 0.24);
+  --accent-gradient: linear-gradient(125deg, var(--accent-start) 0%, var(--accent-mid) 52%, var(--accent-end) 100%);
+  --glow-ember: 0 0 64px rgba(255, 110, 70, 0.34);
+  --glow-crimson: 0 0 74px rgba(177, 49, 43, 0.34);
+  --shadow-soft: 0 30px 96px rgba(1, 0, 2, 0.82);
 
-  --bistre: #131420;
-  --smoky-black: #020203;
-  --space-cadet: #161724;
-  --lion: #ff6f3c;
-  --raisin-black: #0a0b12;
-  --accent-teal: #ff6f3c;
-  --accent-emerald: #ff3d2e;
-  --accent-cyan: #d72638;
-  --glacier: #fff0e4;
+  --bistre: #170b0f;
+  --smoky-black: #040103;
+  --space-cadet: #11060d;
+  --lion: #ff6434;
+  --raisin-black: #080307;
+  --accent-teal: #ff6434;
+  --accent-emerald: #f13a33;
+  --accent-cyan: #b6212d;
+  --glacier: #ffefe3;
 }
 
 @layer base {
@@ -147,31 +153,31 @@
   }
   .glass {
     @apply backdrop-blur-xl;
-    background: rgba(20, 22, 32, 0.6);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(24, 12, 16, 0.62);
+    border: 1px solid var(--border);
   }
   .dark .glass {
-    background: rgba(10, 11, 18, 0.65);
-    border-color: rgba(255, 255, 255, 0.1);
+    background: rgba(16, 8, 10, 0.68);
+    border-color: var(--border);
   }
   .surface-card {
-    background: linear-gradient(140deg, rgba(22, 23, 35, 0.95), rgba(10, 12, 18, 0.9));
+    background: linear-gradient(135deg, rgba(26, 13, 18, 0.95), rgba(9, 4, 6, 0.94));
     border: 1px solid var(--border);
     box-shadow: var(--shadow-soft);
   }
   .surface-panel {
-    background: linear-gradient(160deg, rgba(16, 18, 26, 0.92), rgba(8, 9, 15, 0.88));
-    border: 1px solid rgba(255, 255, 255, 0.06);
+    background: linear-gradient(160deg, rgba(20, 10, 14, 0.94), rgba(8, 3, 6, 0.88));
+    border: 1px solid var(--border);
   }
   .accent-bar {
     height: 2px;
     width: 100%;
     background-image: var(--accent-gradient);
-    filter: drop-shadow(0 0 14px rgba(255, 99, 52, 0.38));
+    filter: drop-shadow(0 0 14px rgba(255, 102, 64, 0.35));
   }
   .nav-chip {
-    background: linear-gradient(120deg, rgba(255, 111, 60, 0.18), rgba(215, 38, 56, 0.16));
-    border: 1px solid rgba(255, 111, 60, 0.4);
+    background: linear-gradient(120deg, rgba(255, 100, 52, 0.24), rgba(177, 45, 40, 0.16));
+    border: 1px solid rgba(255, 124, 80, 0.4);
   }
 }
 
@@ -209,7 +215,7 @@
     box-shadow: var(--shadow-soft);
   }
   .border-glow {
-    box-shadow: 0 0 0 1px rgba(255, 111, 60, 0.18), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+    box-shadow: 0 0 0 1px rgba(255, 124, 80, 0.22), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   }
   .grain {
     background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='60' height='60' viewBox='0 0 60 60'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='60' height='60' filter='url(%23n)' opacity='0.35'/></svg>");


### PR DESCRIPTION
## Summary
- deepen the volcanic color system and surface treatments via updated CSS variables
- refresh header, footer, and CTA components to use the new darker gradient accents
- apply the matured dark palette across home, about, careers, and contact pages including forms

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d7255c8d84832f80bd89f3fe6955fa