### PR TITLE
Refine About page messaging

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -9,139 +9,91 @@ import { Button } from '@/components/ui/button'
 
 const heroMetrics = [
   {
-    value: '120M+',
-    label: 'Citizen records harmonised',
-    copy: 'Registries for residents, businesses, and land brought into a single sovereign fabric.',
+    value: '60 days',
+    label: 'Mandate to launch',
+    copy: 'Policy, procurement, and platform tracks run in one lane so momentum never stalls.',
   },
   {
-    value: '6 weeks',
-    label: 'Average mobilisation',
-    copy: 'From charter to production pilots with co-created policy, service, and engineering playbooks.',
+    value: '3 continents',
+    label: 'Delivery footprint',
+    copy: 'On-site squads across Africa, Europe, and North America keep ministries, citizens, and partners aligned.',
   },
   {
-    value: '24/7',
-    label: 'Assurance coverage',
-    copy: 'Operations centres spanning Lagos, London, and Toronto for uninterrupted continuity.',
+    value: '0 lock-in',
+    label: 'Sovereign control',
+    copy: 'Open standards, transparent code, and graceful handovers mean every client owns their future roadmap.',
   },
 ]
 
 const serviceTracks = [
   {
-    kicker: 'Registry spine',
-    title: 'Sovereign identity and records',
+    kicker: 'Government mandates',
+    title: 'Leaders stay accountable',
     description:
-      'We modernise population, business, and land registries so verification is instant and auditable for ministries and citizens alike.',
+      'Cabinet priorities translate into dashboards, playbooks, and legislation-ready documentation that withstand scrutiny.',
     highlights: [
-      'National encryption, lineage, and dispute workflows',
-      'API gateways for banks, justice, and social services',
-      'Offline-first enrolment for rural communities',
+      'Portfolio control rooms tuned for ministers and boards',
+      'Procurement-ready architectures with audited security patterns',
+      'Embedded advisors who stay through handover',
     ],
   },
   {
-    kicker: 'Digital platform',
-    title: 'Civic service fabric',
+    kicker: 'Civic life',
+    title: 'People feel the difference',
     description:
-      'Human-centred portals, payments, and case management built on composable services that respect local policy and procurement realities.',
+      'Services speak the language of residents, entrepreneurs, and caregivers, reducing friction on every channel.',
     highlights: [
-      'Pattern libraries for permits, licenses, and relief',
-      'Intake to fulfilment orchestrated across agencies',
-      'Performance telemetry that boards and residents trust',
+      'Unified journeys for permits, benefits, and relief',
+      'Offline-ready enrolment for rural and informal communities',
+      'Accessibility rituals that build long-term trust',
     ],
   },
   {
-    kicker: 'Public intelligence',
-    title: 'Insights that sustain confidence',
+    kicker: 'Enterprise ecosystem',
+    title: 'Markets gain clarity',
     description:
-      'We surface mission metrics, fraud analytics, and adoption dashboards so leaders can prove value and course-correct in days, not quarters.',
+      'Banks, logistics firms, and innovators integrate once and operate with confidence in the data they receive.',
     highlights: [
-      'Executive command centres with situation rooms',
-      'Explainable AI scorecards and policy simulations',
-      'Continuous feedback rituals with the public',
+      'Resilient APIs with real-time verification signals',
+      'Fraud, risk, and trade analytics that unlock investment',
+      'Change communications choreographed with industry bodies',
     ],
   },
 ]
 
 const programmeLayers = [
   {
-    id: 'registry',
-    title: 'Registry backbone',
-    copy: 'A lattice of secure registries that unifies identity, assets, and entitlements. We marry document digitisation with biometric capture, consent logging, and tamper-evident ledgers so every record can be trusted in court or across borders.',
+    id: 'confidence',
+    title: 'Confidence by design',
+    copy: 'We harden registries, signatures, and audit trails so decisions hold in cabinet, in court, and in public perception.',
   },
   {
-    id: 'service-fabric',
-    title: 'Service delivery fabric',
-    copy: 'Composable micro frontends, workflow engines, and communications pipes stitched into one operator console. Residents glide from online to in-person support, while ministries gain real-time visibility into queues, payments, and resolution pacing.',
+    id: 'continuity',
+    title: 'Continuity in motion',
+    copy: 'Hybrid operations centres and incident rituals keep critical services steady through elections, transitions, and crises.',
   },
   {
-    id: 'trust-labs',
-    title: 'Trust & verification labs',
-    copy: 'Joint lab environments where we run red-team drills, simulate outage scenarios, and audit algorithmic decisions. Every release leaves with compliance artefacts, multilingual playbooks, and continuity rehearsals for frontline teams.',
+    id: 'clarity',
+    title: 'Clarity for every stakeholder',
+    copy: 'Telemetry, storytelling, and policy notes translate complex delivery work into signals that citizens and investors understand.',
   },
 ]
 
 const operatingPrinciples = [
   {
-    title: 'Public-first rituals',
+    title: 'Stay close to the street',
     detail:
-      'Neighbourhood clinics, youth councils, and commerce forums feed insight into every sprint, ensuring products reflect lived realities and not just policy text.',
+      'Community interviews, executive roundtables, and industry briefings feed each release so impact is tangible.',
   },
   {
-    title: 'Policy-aware engineering',
+    title: 'Engineer for oversight',
     detail:
-      'Architectures are co-signed by legal, procurement, and cyber teams. We document decision logs so oversight bodies can trace every change.',
+      'Traceable architectures, compliance artefacts, and open repositories give regulators and partners full visibility.',
   },
   {
-    title: 'Measured adoption',
+    title: 'Measure what matters',
     detail:
-      'Success is defined by citizens served, hours returned to civil servants, and the integrity of the data flowing through the platform.',
-  },
-]
-
-const timeline = [
-  {
-    year: '2017',
-    title: 'Arctura founded',
-    description:
-      'Delivery leads from African, European, and North American governments formed Arctura to industrialise civic digital programmes.',
-  },
-  {
-    year: '2019',
-    title: 'Registry accelerators launched',
-    description:
-      'Introduced ingestion pipelines, deduplication heuristics, and QR verification stacks tailored to ministries of interior and trade.',
-  },
-  {
-    year: '2021',
-    title: 'Digital platform studio',
-    description:
-      'Opened service design labs in Abuja and London to co-create permitting, licensing, and benefits experiences with the public.',
-  },
-  {
-    year: '2023',
-    title: 'Trust labs network',
-    description:
-      'Established joint verification centres with partners in Lagos, Toronto, and Dubai to stress-test AI, biometrics, and continuity drills.',
-  },
-]
-
-const teamScenes = [
-  {
-    image: '/brand/christina-wocintechchat-com-UcZcsHSp8o4-unsplash.jpg',
-    label: 'Public experience studio',
-    caption:
-      'Service designers and civic researchers co-creating language, visuals, and accessibility journeys with residents and field officers.',
-  },
-  {
-    image: '/brand/jeffery-ho-oITfawv6t-8-unsplash.jpg',
-    label: 'Platform engineering guild',
-    caption:
-      'Cloud, security, and data engineers choreographing registry pipelines, resilience tests, and rollout dashboards in tandem.',
-  },
-  {
-    image: '/brand/brooke-cagle-g1Kr4Ozfoac-unsplash.jpg',
-    label: 'Partner enablement',
-    caption:
-      'Change coaches and programme directors preparing ministries for launch day with training arcs and executive storytelling.',
+      'We report on citizens served, hours saved, and capital unlocked—not vanity metrics.',
   },
 ]
 
@@ -177,14 +129,12 @@ export default function AboutPage() {
               About Arctura
             </span>
             <h1 className="text-balance text-4xl font-black leading-tight sm:text-5xl lg:text-6xl">
-              We choreograph national registries and digital platforms so the public experiences
-              confident, human government.
+              We design sovereign digital infrastructure that earns confidence from cabinet rooms,
+              citizens, and markets alike.
             </h1>
             <p className="max-w-2xl text-balance text-base text-muted sm:text-lg">
-              From the eGovRegistry backbone in Nigeria to modular civic platforms across emerging
-              cities, Arctura blends policy, engineering, and service design into one disciplined
-              squad. We help ministries deliver certainty to citizens, businesses, and partners at
-              scale.
+              Our squads fuse policy, engineering, and service design so every mandate—whether
+              national ID, digital permitting, or investor onboarding—lands fast and feels human.
             </p>
           </motion.div>
           <div className="grid gap-4 sm:grid-cols-3">
@@ -217,15 +167,14 @@ export default function AboutPage() {
         <Container className="space-y-12">
           <div className="max-w-3xl space-y-5">
             <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
-              What we deliver
+              Who we empower
             </span>
             <h2 className="text-3xl font-black sm:text-4xl">
-              Programmes that connect ministries, markets, and everyday people.
+              One programme serving governments, residents, and enterprise allies.
             </h2>
             <p className="text-base text-muted sm:text-lg">
-              Our cross-functional squads translate policy mandates into real products. Each track
-              merges lessons from the digital platform and registry initiatives into one coherent
-              journey.
+              Every engagement blends regulatory rigour with human-centred delivery so leadership
+              can move decisively and the public feels the shift immediately.
             </p>
           </div>
           <div className="grid gap-6 md:grid-cols-3">
@@ -268,15 +217,14 @@ export default function AboutPage() {
         <Container className="space-y-12">
           <div className="max-w-3xl space-y-5">
             <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
-              Programme layers
+              What you gain
             </span>
             <h2 className="text-3xl font-black sm:text-4xl">
-              One backbone, three pillars of delivery.
+              Three pillars that keep transformation steady.
             </h2>
             <p className="text-base text-muted sm:text-lg">
-              Each layer is anchored in the commitments we made across the eGovRegistry and digital
-              platform programmes. Together they guarantee continuity, accountability, and care for
-              the public.
+              Confidence, continuity, and clarity are engineered together so mandates survive
+              elections, audits, and public opinion.
             </p>
           </div>
           <div className="grid gap-6 md:grid-cols-3">
@@ -312,15 +260,14 @@ export default function AboutPage() {
         <Container className="space-y-12">
           <div className="max-w-3xl space-y-5">
             <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
-              How we operate
+              How we work
             </span>
             <h2 className="text-3xl font-black sm:text-4xl">
-              Guardrails that keep programmes human, secure, and measurable.
+              Guardrails that keep delivery human, secure, and provable.
             </h2>
             <p className="text-base text-muted sm:text-lg">
-              Beyond software delivery, we nurture the operating culture needed for change to stick.
-              These principles guide every stand-up, every deployment, and every town-hall we
-              facilitate.
+              We stay embedded from charter to steady state, building the rituals and evidence your
+              teams need to lead with conviction.
             </p>
           </div>
           <div className="grid gap-6 md:grid-cols-3">
@@ -342,45 +289,6 @@ export default function AboutPage() {
       </Section>
 
       <Section className="relative overflow-hidden py-24">
-        <div
-          className="absolute inset-0 -z-10 bg-[radial-gradient(120%_160%_at_50%_0%,rgba(90,32,40,0.22),transparent_70%),linear-gradient(180deg,rgba(12,6,8,0.95),rgba(5,3,4,0.92))]"
-          aria-hidden
-        />
-        <Container className="space-y-12">
-          <div className="max-w-3xl space-y-5">
-            <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
-              Our journey
-            </span>
-            <h2 className="text-3xl font-black sm:text-4xl">
-              Years of public digital work in one timeline.
-            </h2>
-            <p className="text-base text-muted sm:text-lg">
-              Every milestone is tied to a partnership where citizens felt the difference. We keep
-              those lessons alive across new mandates.
-            </p>
-          </div>
-          <ol className="grid gap-6 md:grid-cols-2">
-            {timeline.map((item, index) => (
-              <motion.li
-                key={item.year}
-                initial={reduceMotion ? undefined : { opacity: 0, y: 24 }}
-                whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
-                viewport={{ once: true, amount: 0.3 }}
-                transition={{ duration: 0.5, ease: 'easeOut', delay: index * 0.05 }}
-                className="surface-card flex h-full flex-col gap-3 rounded-[24px] border border-[color:var(--border)] p-6"
-              >
-                <span className="text-xs font-semibold uppercase tracking-[0.32em] text-muted">
-                  {item.year}
-                </span>
-                <h3 className="text-lg font-semibold text-[color:var(--ink)]">{item.title}</h3>
-                <p className="text-sm text-muted">{item.description}</p>
-              </motion.li>
-            ))}
-          </ol>
-        </Container>
-      </Section>
-
-      <Section className="relative overflow-hidden py-24">
         <div className="absolute inset-0 -z-10">
           <div
             className="absolute inset-x-0 top-[20%] h-48 bg-[radial-gradient(65%_140%_at_50%_0%,rgba(255,112,68,0.18),transparent_70%)]"
@@ -388,48 +296,17 @@ export default function AboutPage() {
           />
         </div>
         <Container className="space-y-12">
-          <div className="mx-auto max-w-4xl text-center">
-            <span className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
-              Inside Arctura
+          <div className="mx-auto max-w-3xl text-center space-y-6">
+            <span className="inline-flex items-center justify-center gap-2 rounded-full border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-2 text-[0.68rem] font-semibold uppercase tracking-[0.38em] text-muted">
+              Partner with Arctura
             </span>
-            <h2 className="mt-6 text-3xl font-black sm:text-4xl">
-              Multidisciplinary teams that stay in the arena with you.
+            <h2 className="text-3xl font-black sm:text-4xl">
+              Bring us the mandate you cannot afford to fumble.
             </h2>
-            <p className="mt-4 text-base text-muted sm:text-lg">
-              The same people who design resident journeys also review policy drafts, rehearse
-              continuity drills, and brief cabinet members. We remain embedded until your teams can
-              run independently.
+            <p className="text-base text-muted sm:text-lg">
+              We assemble a tailored squad—policy strategists, engineers, storytellers—to move the
+              nation, the community, and the market in unison.
             </p>
-          </div>
-          <div className="grid gap-6 md:grid-cols-3">
-            {teamScenes.map((scene, index) => (
-              <motion.figure
-                key={scene.label}
-                initial={reduceMotion ? undefined : { opacity: 0, y: 30 }}
-                whileInView={reduceMotion ? undefined : { opacity: 1, y: 0 }}
-                viewport={{ once: true, amount: 0.3 }}
-                transition={{ duration: 0.55, ease: 'easeOut', delay: index * 0.08 }}
-                className="surface-panel flex h-full flex-col overflow-hidden rounded-[28px] border border-[color:var(--border)]"
-              >
-                <div className="relative h-60">
-                  <Image
-                    src={scene.image}
-                    alt={scene.label}
-                    fill
-                    sizes="(min-width: 1024px) 360px, (min-width: 640px) 45vw, 100vw"
-                    className="object-cover"
-                  />
-                  <div
-                    className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/30 to-transparent"
-                    aria-hidden
-                  />
-                  <figcaption className="absolute bottom-4 left-4 text-sm font-semibold uppercase tracking-[0.32em] text-[color:var(--glacier)]/80">
-                    {scene.label}
-                  </figcaption>
-                </div>
-                <p className="p-6 text-sm text-muted">{scene.caption}</p>
-              </motion.figure>
-            ))}
           </div>
           <motion.div
             initial={reduceMotion ? undefined : { opacity: 0, y: 36 }}
@@ -439,11 +316,11 @@ export default function AboutPage() {
             className="mx-auto flex max-w-3xl flex-col items-center rounded-[32px] border border-[color:var(--border)] bg-[linear-gradient(125deg,rgba(24,12,16,0.95),rgba(10,5,8,0.9))] p-10 text-center shadow-[0_40px_120px_rgba(6,3,5,0.6)]"
           >
             <h3 className="text-2xl font-semibold text-[color:var(--ink)] md:text-3xl">
-              Ready to design the next chapter of your public digital infrastructure?
+              Ready to move policy, people, and partners together?
             </h3>
             <p className="mt-4 text-sm text-muted sm:text-base">
-              Share your mission and constraints. We will assemble an Arctura squad that blends
-              registry, platform, and change expertise tailored to your mandate.
+              Tell us where confidence is fragile. We will script the path from pilot to national
+              proof with you.
             </p>
             <Button
               asChild


### PR DESCRIPTION
## Summary
- streamline the About page narrative to focus on confident, human-centred delivery for governments, citizens, and enterprises
- refactor supporting sections into concise pillars that highlight accountability, continuity, and clarity
- remove dated timeline and team galleries in favor of a direct partnership invitation that maintains the existing visual theme

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d73a04c3fc832fbdd7c3be20f24406