### PR TITLE
Allow ParticleField canvas to accept styling props

### DIFF
--- a/src/components/particles.tsx
+++ b/src/components/particles.tsx
@@ -1,9 +1,12 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
-import { motion } from 'framer-motion'
+import { type ComponentPropsWithoutRef, useEffect, useRef } from 'react'
 
-export function ParticleField() {
+import { cn } from '@/lib/utils'
+
+type ParticleFieldProps = ComponentPropsWithoutRef<'canvas'>
+
+export function ParticleField({ className, style, ...props }: ParticleFieldProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const particles = useRef<Array<{ x: number; y: number; vx: number; vy: number; size: number }>>([])
   const animationFrameId = useRef<number>()
@@ -85,8 +88,9 @@ export function ParticleField() {
   return (
     <canvas
       ref={canvasRef}
-      className="absolute inset-0 z-0"
-      style={{ opacity: 0.6 }}
+      className={cn('absolute inset-0 z-0', className)}
+      style={style ? { opacity: 0.6, ...style } : { opacity: 0.6 }}
+      {...props}
     />
   )
 }


### PR DESCRIPTION
## Summary
- allow the ParticleField canvas to accept standard canvas props so pages can control styling and accessibility
- merge incoming class names and styles with defaults while forwarding the remaining props

## Testing
- npm run build *(fails: unable to fetch Google Fonts in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d751f951dc832f94354d94c95f07fd