### PR TITLE
Fix deployment build by avoiding remote font fetch

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,25 +1,10 @@
+/* eslint-disable @next/next/no-page-custom-font */
 import type { Metadata, Viewport } from 'next'
-import { Montserrat, Open_Sans } from 'next/font/google'
 import '@/styles/globals.css'
 import { Header } from '@/components/header'
 import { Footer } from '@/components/footer'
 import { Analytics } from '@/components/analytics'
 import { OrganizationJsonLd, defaultMetadata } from '@/lib/seo'
-
-const montserrat = Montserrat({
-  subsets: ['latin'],
-  weight: ['700'],
-  display: 'swap',
-  preload: true,
-  variable: '--font-heading'
-})
-const openSans = Open_Sans({
-  subsets: ['latin'],
-  weight: ['400'],
-  display: 'swap',
-  preload: true,
-  variable: '--font-body'
-})
 
 export const metadata: Metadata = defaultMetadata
 
@@ -31,7 +16,16 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning className="dark">
-      <body className={`${openSans.variable} ${montserrat.variable} bg-bg text-ink antialiased`}>
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Open+Sans:wght@400&display=swap"
+        />
+      </head>
+      {/* eslint-enable @next/next/no-page-custom-font */}
+      <body className="bg-bg text-ink antialiased">
         <a href="#content" className="skip-link">Skip to content</a>
         <OrganizationJsonLd />
         <Header />

--- a/src/components/email-capture.tsx
+++ b/src/components/email-capture.tsx
@@ -2,10 +2,16 @@
 
 import { motion } from 'framer-motion'
 import { Container } from './container'
+import { cn } from '@/lib/utils'
 
-export function EmailCapture() {
+interface EmailCaptureProps {
+  className?: string
+  submitLabel?: string
+}
+
+export function EmailCapture({ className, submitLabel }: EmailCaptureProps) {
   return (
-    <section className="relative py-24 overflow-hidden">
+    <section className={cn('relative py-24 overflow-hidden', className)}>
       <div className="absolute inset-0 bg-gradient-to-br from-[#1a0f1f] via-[#160809] to-[#0a0a0a]" />
 
       {/* Animated gradient backgrounds */}
@@ -60,7 +66,7 @@ export function EmailCapture() {
                 href="mailto:hello@arctura-analytics.com"
                 className="w-full sm:w-auto inline-flex items-center justify-center rounded-full bg-gradient-to-r from-[#ff4d4d] to-[#ff6b00] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-[#ff4d4d]/10 transition-transform duration-300 hover:scale-[1.02]"
               >
-                Email hello@arctura-analytics.com
+                {submitLabel ?? 'Email hello@arctura-analytics.com'}
               </a>
             </div>
           </motion.div>

--- a/src/components/icon-grid.tsx
+++ b/src/components/icon-grid.tsx
@@ -1,15 +1,7 @@
 'use client'
 
 import { motion } from 'framer-motion'
-import { 
-  BarChart3, 
-  Database, 
-  Network, 
-  Shield, 
-  Cpu, 
-  Users,
-  type Icon as LucideIcon
-} from 'lucide-react'
+import { BarChart3, Database, Network, Shield, Cpu, Users, type LucideIcon } from 'lucide-react'
 
 type IconWrapperProps = {
   icon: LucideIcon

--- a/src/components/particles.tsx
+++ b/src/components/particles.tsx
@@ -1,9 +1,11 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import { motion } from 'framer-motion'
+import { cn } from '@/lib/utils'
 
-export function ParticleField() {
+type ParticleFieldProps = React.ComponentProps<'canvas'>
+
+export function ParticleField({ className, style, ...props }: ParticleFieldProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const particles = useRef<Array<{ x: number; y: number; vx: number; vy: number; size: number }>>([])
   const animationFrameId = useRef<number>()
@@ -85,8 +87,9 @@ export function ParticleField() {
   return (
     <canvas
       ref={canvasRef}
-      className="absolute inset-0 z-0"
-      style={{ opacity: 0.6 }}
+      className={cn('absolute inset-0 z-0', className)}
+      style={{ opacity: 0.6, ...style }}
+      {...props}
     />
   )
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -38,6 +38,8 @@
   --accent-emerald: #f13a33;
   --accent-cyan: #b6212d;
   --glacier: #fff2ea;
+  --font-body: 'Open Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-heading: 'Montserrat', 'Open Sans', 'Inter', system-ui;
 }
 
 .dark {
@@ -74,6 +76,8 @@
   --accent-emerald: #f13a33;
   --accent-cyan: #b6212d;
   --glacier: #ffefe3;
+  --font-body: 'Open Sans', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-heading: 'Montserrat', 'Open Sans', 'Inter', system-ui;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- load Montserrat and Open Sans via standard `<link>` tags and CSS variables so builds no longer fetch fonts during compilation
- update particle field and email capture components to accept style/class props and fix lucide icon typing issues uncovered by type-checking

## Testing
- `npm run build`
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68d75b74fbf0832f9fc07238a57cf21c