### PR TITLE
Align mobile menu button to right edge

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -88,7 +88,7 @@ export function Header() {
         </nav>
 
         {/* CTA + Mobile toggle */}
-        <div className="flex items-center gap-2">
+        <div className="ml-auto flex items-center gap-2">
           <button
             type="button"
             className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-[color:var(--border)] text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--ink)] md:hidden"


### PR DESCRIPTION
## Summary
- add automatic margin on the header action container so the mobile menu button sits at the edge of the screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7651c24a0832fb3007df25291b997