### PR TITLE
feat: refresh brand logo styling

### DIFF
--- a/public/brand/logo-dark.svg
+++ b/public/brand/logo-dark.svg
@@ -1,11 +1,32 @@
 <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#0066CC"/>
-      <stop offset="1" stop-color="#3398FF"/>
+    <linearGradient id="brand-outer" x1="44" y1="32" x2="220" y2="216" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FF3600" />
+      <stop offset="0.6" stop-color="#FF5C12" />
+      <stop offset="1" stop-color="#FF8936" />
     </linearGradient>
+    <linearGradient id="brand-inner" x1="112" y1="104" x2="200" y2="200" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1A0600" />
+      <stop offset="1" stop-color="#2E0A03" />
+    </linearGradient>
+    <radialGradient id="brand-glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(128 168) scale(120 80)">
+      <stop offset="0" stop-color="#FF6A2A" stop-opacity="0.35" />
+      <stop offset="1" stop-color="#FF6A2A" stop-opacity="0" />
+    </radialGradient>
   </defs>
-  <rect width="256" height="256" rx="56" fill="#0D1B2A"/>
-  <path d="M128 48c-6.6 0-12.7 3.4-16.2 9L48 176c-6.8 11 1.1 25 14.2 25h31.7c6.5 0 12.5-3.3 16-8.8l18-28.2a8 8 0 0 1 13.4 0l18 28.2c3.5 5.5 9.5 8.8 16 8.8h31.7c13 0 21-14 14.2-25L144.2 57c-3.5-5.6-9.6-9-16.2-9Zm0 56 20.8 33.1a8 8 0 0 1-6.8 12.3h-27.9a8 8 0 0 1-6.8-12.3L128 104Z" fill="url(#g)"/>
+  <rect width="256" height="256" rx="56" fill="#050607" />
+  <g filter="url(#brand-shadow)">
+    <path d="M128 32 28 224h60l19-37.2c6.4-12.4 19-20.2 32.7-20.2h16.6c13.7 0 26.3 7.8 32.7 20.2L207 224h60L128 32Z" fill="url(#brand-outer)" />
+    <path d="M127.4 92.5 94 156h29l14-26.6c3.6-6.7 10.4-11 17.9-11h2.8c7.5 0 14.3 4.3 17.9 11l14 26.6h29L160.6 92.5c-6.8-12.7-26.5-12.7-33.2 0Z" fill="url(#brand-inner)" />
+    <path d="M154 170.8c-3.1-5.8-9.2-9.3-15.7-9.3h-8.6c-6.5 0-12.6 3.5-15.7 9.3L103 192h62l-11-21.2Z" fill="#FF6121" fill-opacity="0.42" />
+    <path d="M94 186c20.8-18.7 49.5-29 77.6-27.1" stroke="#FF9A55" stroke-width="6" stroke-linecap="round" stroke-opacity="0.42" />
+  </g>
+  <rect width="256" height="256" rx="56" fill="url(#brand-glow)" />
+  <defs>
+    <filter id="brand-shadow" x="8" y="20" width="240" height="228" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+      <feGaussianBlur stdDeviation="7" result="effect1_foregroundBlur" />
+    </filter>
+  </defs>
 </svg>
-

--- a/public/brand/logo-light.svg
+++ b/public/brand/logo-light.svg
@@ -1,11 +1,32 @@
 <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#0066CC"/>
-      <stop offset="1" stop-color="#3398FF"/>
+    <linearGradient id="brand-outer-light" x1="44" y1="32" x2="220" y2="216" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FF3E00" />
+      <stop offset="0.6" stop-color="#FF6218" />
+      <stop offset="1" stop-color="#FF8F3E" />
     </linearGradient>
+    <linearGradient id="brand-inner-light" x1="112" y1="104" x2="200" y2="200" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#371104" />
+      <stop offset="1" stop-color="#4A1707" />
+    </linearGradient>
+    <radialGradient id="brand-glow-light" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(128 168) scale(120 80)">
+      <stop offset="0" stop-color="#FF6A2A" stop-opacity="0.25" />
+      <stop offset="1" stop-color="#FF6A2A" stop-opacity="0" />
+    </radialGradient>
   </defs>
-  <rect width="256" height="256" rx="56" fill="#FFFFFF"/>
-  <path d="M128 48c-6.6 0-12.7 3.4-16.2 9L48 176c-6.8 11 1.1 25 14.2 25h31.7c6.5 0 12.5-3.3 16-8.8l18-28.2a8 8 0 0 1 13.4 0l18 28.2c3.5 5.5 9.5 8.8 16 8.8h31.7c13 0 21-14 14.2-25L144.2 57c-3.5-5.6-9.6-9-16.2-9Zm0 56 20.8 33.1a8 8 0 0 1-6.8 12.3h-27.9a8 8 0 0 1-6.8-12.3L128 104Z" fill="url(#g)"/>
+  <rect width="256" height="256" rx="56" fill="#FFFFFF" />
+  <g filter="url(#brand-shadow-light)">
+    <path d="M128 32 28 224h60l19-37.2c6.4-12.4 19-20.2 32.7-20.2h16.6c13.7 0 26.3 7.8 32.7 20.2L207 224h60L128 32Z" fill="url(#brand-outer-light)" />
+    <path d="M127.4 92.5 94 156h29l14-26.6c3.6-6.7 10.4-11 17.9-11h2.8c7.5 0 14.3 4.3 17.9 11l14 26.6h29L160.6 92.5c-6.8-12.7-26.5-12.7-33.2 0Z" fill="url(#brand-inner-light)" />
+    <path d="M154 170.8c-3.1-5.8-9.2-9.3-15.7-9.3h-8.6c-6.5 0-12.6 3.5-15.7 9.3L103 192h62l-11-21.2Z" fill="#FF6121" fill-opacity="0.42" />
+    <path d="M94 186c20.8-18.7 49.5-29 77.6-27.1" stroke="#FF9A55" stroke-width="6" stroke-linecap="round" stroke-opacity="0.4" />
+  </g>
+  <rect width="256" height="256" rx="56" fill="url(#brand-glow-light)" />
+  <defs>
+    <filter id="brand-shadow-light" x="8" y="20" width="240" height="228" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+      <feGaussianBlur stdDeviation="6" result="effect1_foregroundBlur" />
+    </filter>
+  </defs>
 </svg>
-

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,12 +1,32 @@
 <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#10B4E8"/>
-      <stop offset="0.6" stop-color="#2970FF"/>
-      <stop offset="1" stop-color="#6C4DF6"/>
+    <linearGradient id="outer" x1="38" y1="24" x2="218" y2="232" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FF3200" />
+      <stop offset="0.58" stop-color="#FF5A10" />
+      <stop offset="1" stop-color="#FF8A3D" />
     </linearGradient>
+    <linearGradient id="inner" x1="96" y1="88" x2="196" y2="196" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#180400" />
+      <stop offset="1" stop-color="#2A0903" />
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(128 168) scale(120 80)">
+      <stop offset="0" stop-color="#FF6A2A" stop-opacity="0.45" />
+      <stop offset="1" stop-color="#FF6A2A" stop-opacity="0" />
+    </radialGradient>
   </defs>
-  <rect width="256" height="256" rx="56" fill="#0B1020"/>
-  <path d="M128 48c-6.6 0-12.7 3.4-16.2 9L48 176c-6.8 11 1.1 25 14.2 25h31.7c6.5 0 12.5-3.3 16-8.8l18-28.2a8 8 0 0 1 13.4 0l18 28.2c3.5 5.5 9.5 8.8 16 8.8h31.7c13 0 21-14 14.2-25L144.2 57c-3.5-5.6-9.6-9-16.2-9Zm0 56 20.8 33.1a8 8 0 0 1-6.8 12.3h-27.9a8 8 0 0 1-6.8-12.3L128 104Z" fill="url(#g)"/>
+  <rect width="256" height="256" rx="56" fill="#070809" />
+  <g filter="url(#shadow)">
+    <path d="M128 32 30 224h56l18-35c6-11 17.7-18 30.6-18h14.8c12.9 0 24.7 7 30.6 18l18 35h56L128 32Z" fill="url(#outer)" />
+    <path d="M127.6 90.3 96 152h26.4l13-24.6c3.3-6.3 9.7-10.4 16.7-10.4H156c7 0 13.4 4 16.7 10.4L186 152h26.4L157.9 90.3c-6.3-12.3-23.9-12.3-30.3 0Z" fill="url(#inner)" />
+    <path d="M152 168c-3-5.6-8.9-9-15.1-9h-7.8c-6.2 0-12.1 3.4-15.1 9l-9.4 17.7h56.8L152 168Z" fill="#FF6121" fill-opacity="0.4" />
+    <path d="M96 182c18.9-17 44.7-26.4 70-24.7" stroke="#FF9550" stroke-width="6" stroke-linecap="round" stroke-opacity="0.45" />
+  </g>
+  <rect width="256" height="256" rx="56" fill="url(#glow)" />
+  <defs>
+    <filter id="shadow" x="10" y="22" width="236" height="222" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+      <feGaussianBlur stdDeviation="6" result="effect1_foregroundBlur" />
+    </filter>
+  </defs>
 </svg>
-

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -57,11 +57,7 @@ export function Navbar() {
           }
         >
           <div className="flex items-center justify-between md:hidden">
-            <Logo
-              usePng
-              size={42}
-              textClassName="text-white text-sm font-black uppercase tracking-[0.32em]"
-            />
+            <Logo size={42} />
             <button
               className="flex h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/80 transition hover:border-white/30 hover:bg-white/10"
               aria-label={open ? 'Close menu' : 'Open menu'}
@@ -73,11 +69,7 @@ export function Navbar() {
 
           <div className="hidden items-center justify-between md:flex">
             <div className="flex items-center gap-4">
-              <Logo
-                usePng
-                size={46}
-                textClassName="text-white text-xs font-black uppercase tracking-[0.42em] lg:text-sm"
-              />
+              <Logo size={46} />
               <span className="hidden lg:inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-[0.62rem] font-semibold uppercase tracking-[0.38em] text-white/60">
                 Data platform specialists
               </span>
@@ -134,11 +126,7 @@ export function Navbar() {
             className="fixed inset-y-4 right-4 z-50 flex h-[92vh] max-w-sm flex-col rounded-3xl border border-white/10 bg-[color:rgba(7,9,14,0.96)] p-6 shadow-[0_28px_80px_rgba(2,3,9,0.75)] md:hidden"
           >
             <div className="mb-6 flex items-center justify-between">
-              <Logo
-                usePng
-                size={40}
-                textClassName="text-white text-sm font-black uppercase tracking-[0.34em]"
-              />
+              <Logo size={40} />
               <button
                 aria-label="Close menu"
                 className="flex h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-white/5 text-white/80 transition hover:border-white/40 hover:bg-white/10"

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -57,7 +57,7 @@ export function Header() {
           className="flex items-center gap-3 text-[color:var(--ink)]"
           aria-label="Arctura Analytics home"
         >
-          <Logo size={36} withLink={false} showText={true} textClassName="text-lg font-bold tracking-wider" />
+          <Logo size={36} withLink={false} showText />
         </Link>
 
         {/* Desktop nav */}

--- a/src/components/logo.tsx
+++ b/src/components/logo.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import Link from 'next/link'
 
 type LogoVariant = 'dark' | 'light'
@@ -16,11 +15,22 @@ type Props = {
   ariaLabel?: string
 }
 
+const gradients: Record<LogoVariant, { glow: string; text: string }> = {
+  dark: {
+    glow: 'drop-shadow-[0_0_16px_rgba(255,68,0,0.55)]',
+    text: 'from-[#ff4d00] via-[#ff6121] to-[#ff8a3d]',
+  },
+  light: {
+    glow: 'drop-shadow-[0_0_16px_rgba(255,68,0,0.35)]',
+    text: 'from-[#cc2b00] via-[#ff4d00] to-[#ff8a3d]',
+  },
+}
+
 export function Logo({
-  size = 32,
-  priority = true,
+  size = 36,
+  priority: _priority = true, // kept for backwards compatibility
   variant = 'dark',
-  usePng = false,
+  usePng: _usePng = false,
   showText = true,
   textClassName,
   className,
@@ -28,25 +38,64 @@ export function Logo({
   href = '/',
   ariaLabel = 'Arctura Analytics home',
 }: Props) {
-  const src = '/brand/Arctura_Logo.png'
   const containerClass = ['flex items-center gap-3', className].filter(Boolean).join(' ')
+
+  const dimension = Math.round(size * 1.25)
+
   const content = (
     <>
-      <div className="relative">
-        <Image 
-          src={src} 
-          alt="Arctura Analytics" 
-          width={size} 
-          height={size} 
-          priority={priority}
-          className="drop-shadow-[0_0_12px_rgba(255,111,60,0.4)]"
-        />
-        <div className="absolute inset-0 bg-gradient-to-r from-[#ff7b39]/10 to-[#ffb347]/10 mix-blend-overlay rounded-full" />
-      </div>
+      <span className={`relative inline-flex items-center justify-center ${gradients[variant].glow}`}>
+        <svg
+          width={dimension}
+          height={dimension}
+          viewBox="0 0 120 120"
+          role="img"
+          aria-label="Arctura Analytics emblem"
+          className="overflow-visible"
+        >
+          <defs>
+            <linearGradient id="arctura-fire" x1="14" y1="12" x2="108" y2="108" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stopColor="#ff3200" />
+              <stop offset="55%" stopColor="#ff5a10" />
+              <stop offset="100%" stopColor="#ff852d" />
+            </linearGradient>
+            <linearGradient id="arctura-ember" x1="32" y1="40" x2="96" y2="96" gradientUnits="userSpaceOnUse">
+              <stop offset="0%" stopColor="#1b0500" />
+              <stop offset="100%" stopColor="#2d0903" />
+            </linearGradient>
+          </defs>
+          <g fill="none" fillRule="evenodd">
+            <path
+              d="M60 8 8 112h32.4l9.7-18.6c3.2-6.1 9.5-9.9 16.3-9.9h7.2c6.8 0 13.1 3.8 16.3 9.9l9.7 18.6H112L60 8Z"
+              fill="url(#arctura-fire)"
+            />
+            <path
+              d="M59.8 42.2 41.5 78.4h14.3l6.6-12.6c1.8-3.4 5.3-5.6 9.1-5.6h2c3.8 0 7.3 2.2 9.1 5.6l6.6 12.6h14.3L75.2 42.2c-3.4-6.6-12-6.6-15.4 0Z"
+              fill="url(#arctura-ember)"
+            />
+            <path
+              d="M74 85.6c-1.6-2.9-4.7-4.7-8-4.7h-4c-3.3 0-6.4 1.8-8 4.7l-5 9.4h30.1L74 85.6Z"
+              fill="#ff6121"
+              fillOpacity={0.4}
+            />
+            <path
+              d="M38 92c10-8.8 23.7-13.8 37.1-12.9"
+              stroke="#ff9550"
+              strokeWidth={3.2}
+              strokeLinecap="round"
+              strokeOpacity={0.45}
+            />
+          </g>
+        </svg>
+        <span className="absolute inset-[-16%] rounded-[32px] bg-gradient-to-br from-[#ff4d00]/15 via-transparent to-[#ff8a3d]/5 blur-[14px]" />
+      </span>
       {showText ? (
-        <span className={textClassName ?? 'text-base font-bold tracking-wider'}>
-          <span className="bg-gradient-to-r from-[#ff7b39] via-[#ff8a47] to-[#ffb347] bg-clip-text text-transparent">Arctura</span>
-          <span className="text-white/80"> Analytics</span>
+        <span
+          className=
+            {textClassName ?? `text-lg font-black tracking-[0.24em] uppercase text-white drop-shadow-[0_2px_10px_rgba(0,0,0,0.55)]`}
+        >
+          <span className={`bg-gradient-to-r ${gradients[variant].text} bg-clip-text text-transparent`}>Arctura</span>
+          <span className="text-white"> Analytics</span>
         </span>
       ) : null}
     </>


### PR DESCRIPTION
## Summary
- replace blue brand assets with a fiery triangular emblem across light and dark variants
- rebuild the Logo component to render the new SVG badge and reinforced typography
- update header and navigation to showcase the refreshed branding treatment

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d845d7447c832fa9bb6be3439f28bf